### PR TITLE
Added parameter to proper dismiss overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Display given template as a dialog.
 
 ---
 
-### `AntiModals.dismissOverlay()`
+### `AntiModals.dismissOverlay($('.anti-modal-overlay'))`
 
 Dismiss displayed dialog.
 


### PR DESCRIPTION
I think the overlay dismissal would work only when passing the proper element
